### PR TITLE
Fix possible path inconsistency with hook_node_insert and moved files

### DIFF
--- a/includes/filefield_paths.inc
+++ b/includes/filefield_paths.inc
@@ -93,6 +93,9 @@ function filefield_paths_filefield_paths_process_file($type, $entity, array $fie
         if ($file !== $old_file) {
           $dirname = backdrop_dirname($file['uri']);
           if (file_prepare_directory($dirname, FILE_CREATE_DIRECTORY) && $new_file = file_move(entity_create('file', $old_file), $file['uri'])) {
+
+            $file['uri'] = $new_file->uri;
+
             // Process regular expression.
             _filefield_paths_replace_path($old_file['uri'], $file['uri'], $entity);
 

--- a/tests/filefield_paths.general.test
+++ b/tests/filefield_paths.general.test
@@ -319,4 +319,30 @@ class FileFieldPathsGeneralTestCase extends FileFieldPathsTestCase {
     $this->assertEqual("public://node/{$title}/{$title}.txt", $node->{$field_name}[$langcode][0]['uri']);
   }
 
+  /**
+   * Tests the file objects passed to hook_node_insert().
+   */
+  public function testHookNodeInsertUriCollision() {
+    $langcode = LANGUAGE_NONE;
+
+    // Create a multivalue File field with 'node/[node:nid]' as the File path.
+    $field_name = 'ffp_uri_collision';
+    $field_settings['cardinality'] = FIELD_CARDINALITY_UNLIMITED;
+    $instance_settings['filefield_paths']['file_path']['value'] = 'node/[node:nid]';
+    $this->createFileField($field_name, $this->content_type, $field_settings, $instance_settings);
+
+    // Create a node with two test files with the same filename.
+    $text_files = $this->backdropGetTestFiles('text');
+    $this->backdropGet("node/add/{$this->content_type}");
+    $this->backdropPost(NULL, array("files[{$field_name}_{$langcode}_0]" => backdrop_realpath($text_files[0]->uri)), t('Upload'));
+    $edit = array(
+      'title' => 'ffp_uri_collision',
+      "files[{$field_name}_{$langcode}_1]" => backdrop_realpath($text_files[0]->uri),
+    );
+    $this->backdropPost(NULL, $edit, t('Save'));
+
+    $node_insert_uris = array_unique(state_get('ffp_uri_collision_uris', array()));
+    $this->assertTrue(count($node_insert_uris) > 1, 'There were no collisions in the file uris passed to hook_node_insert()');
+  }
+
 }

--- a/tests/filefield_paths_test.module
+++ b/tests/filefield_paths_test.module
@@ -14,3 +14,20 @@ function filefield_paths_test_stream_wrappers_alter(array &$wrappers) {
   $wrappers['ffp']         = $wrappers['public'];
   $wrappers['ffp']['type'] = STREAM_WRAPPERS_READ_VISIBLE;
 }
+
+/**
+ * Implements hook_node_insert().
+ *
+ * @param Node $node
+ *   Node object.
+ */
+function filefield_paths_test_node_insert(Node $node) {
+  if ($node->title == 'ffp_uri_collision') {
+    $files = $node->ffp_uri_collision[LANGUAGE_NONE];
+    $uris = array();
+    foreach ($files as $file) {
+      $uris[] = $file['uri'];
+    }
+    state_set('ffp_uri_collision_uris', $uris);
+  }
+}


### PR DESCRIPTION
Apparently this has been fixed by multiple people, coordinated by Tag1 D7ES, but the info never landed in our queue.